### PR TITLE
Package indexing confuses packages with different parents fix

### DIFF
--- a/Config/Schema/api_generator.php
+++ b/Config/Schema/api_generator.php
@@ -55,6 +55,7 @@ class ApiGeneratorSchema extends CakeSchema {
 	public $api_packages = array(
 		'id' => array('type' => 'string', 'default' => NULL, 'length' => 36, 'null' => false, 'key' => 'primary'),
 		'parent_id' => array('type' => 'string', 'default' => NULL, 'length' => 36, 'null' => true, 'key' => 'index'),
+		'package_path' => array('type' => 'string', 'null' => false, 'length' => 500, 'key' => 'index'),
 		'name' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'slug' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'lft' => array('type' => 'integer'),
@@ -64,6 +65,7 @@ class ApiGeneratorSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => true),
 			'parent_id' => array('column' => 'parent_id', 'unique' => false),
+			'package_path' => array('column' => 'package_path', 'unique' => false),
 		)
 	);
 }

--- a/Config/Schema/api_generator.php
+++ b/Config/Schema/api_generator.php
@@ -55,7 +55,7 @@ class ApiGeneratorSchema extends CakeSchema {
 	public $api_packages = array(
 		'id' => array('type' => 'string', 'default' => NULL, 'length' => 36, 'null' => false, 'key' => 'primary'),
 		'parent_id' => array('type' => 'string', 'default' => NULL, 'length' => 36, 'null' => true, 'key' => 'index'),
-		'package_path' => array('type' => 'string', 'null' => false, 'length' => 500, 'key' => 'index'),
+		'path' => array('type' => 'string', 'null' => false, 'length' => 500, 'key' => 'index'),
 		'name' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'slug' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'lft' => array('type' => 'integer'),
@@ -65,7 +65,7 @@ class ApiGeneratorSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => true),
 			'parent_id' => array('column' => 'parent_id', 'unique' => false),
-			'package_path' => array('column' => 'package_path', 'unique' => false),
+			'path' => array('column' => 'path', 'unique' => false),
 		)
 	);
 }

--- a/Config/routes.php
+++ b/Config/routes.php
@@ -13,3 +13,8 @@ Router::connect('/package/*', array('plugin' => 'api_generator', 'controller' =>
 Router::connect('/file/*', array('plugin' => 'api_generator', 'controller' => 'api_files', 'action' => 'view_file'));
 Router::connect('/view_source/*', array('plugin' => 'api_generator', 'controller' => 'api_classes', 'action' => 'view_source'));
 Router::connect('/search/*', array('plugin' => 'api_generator', 'controller' => 'api_classes', 'action' => 'search'));
+
+/**
+ * Auto-detect json, so it doesn't mess up passedArgs
+ */
+Router::parseExtensions('json');

--- a/Console/Command/ApiIndexShell.php
+++ b/Console/Command/ApiIndexShell.php
@@ -129,6 +129,7 @@ class ApiIndexShell extends Shell {
 		$this->ApiPackage = ClassRegistry::init('ApiGenerator.ApiPackage');
 
 		$this->ApiClass->clearIndex();
+		$this->ApiPackage->clearIndex();
 		$this->ApiFile->importCoreClasses();
 
 		$foundClasses = array();
@@ -148,8 +149,10 @@ class ApiIndexShell extends Shell {
 						$foundClasses[$className] = true;
 						try {
 							$packages = $this->ApiPackage->parsePackage($classDocs->classInfo['comment']);
-							$this->ApiPackage->updatePackageTree($packages);
-							$lastPackage = $this->ApiPackage->findEndPackageId($packages);
+							$lastPackage = $this->ApiPackage->updatePackageTree($packages);
+							if (!$lastPackage) {
+								$lastPackage = $this->ApiPackage->findEndPackageId($packages);
+							}
 							$this->ApiClass->saveField('api_package_id', $lastPackage);
 						} catch (Exception $e) {
 							$this->out(sprintf(

--- a/Controller/ApiPackagesController.php
+++ b/Controller/ApiPackagesController.php
@@ -51,7 +51,11 @@ class ApiPackagesController extends ApiGeneratorAppController {
  *
  * @return void
  **/
-	public function view($packagePath = null) {
+	public function view() {
+		$packagePath = null;
+		if (!empty($this->passedArgs)) {
+			$packagePath = $this->ApiPackage->makePath($this->passedArgs);
+		}
 		if (!$packagePath) {
 			$this->Session->setFlash(__d('api_generator', 'No package name was given'));
 			$this->redirect($this->referer());

--- a/Controller/ApiPackagesController.php
+++ b/Controller/ApiPackagesController.php
@@ -51,12 +51,12 @@ class ApiPackagesController extends ApiGeneratorAppController {
  *
  * @return void
  **/
-	public function view($slug = null) {
-		if (!$slug) {
+	public function view($packagePath = null) {
+		if (!$packagePath) {
 			$this->Session->setFlash(__d('api_generator', 'No package name was given'));
 			$this->redirect($this->referer());
 		}
-		$apiPackage = $this->ApiPackage->findBySlug($slug);
+		$apiPackage = $this->ApiPackage->findByPackagePath($packagePath);
 		if (empty($apiPackage)) {
 			$this->_notFound(__d('api_generator', 'No package exists in the index with that name'));
 		}

--- a/Controller/ApiPackagesController.php
+++ b/Controller/ApiPackagesController.php
@@ -52,15 +52,15 @@ class ApiPackagesController extends ApiGeneratorAppController {
  * @return void
  **/
 	public function view() {
-		$packagePath = null;
+		$path = null;
 		if (!empty($this->passedArgs)) {
-			$packagePath = $this->ApiPackage->makePath($this->passedArgs);
+			$path = $this->ApiPackage->makePath($this->passedArgs);
 		}
-		if (!$packagePath) {
+		if (!$path) {
 			$this->Session->setFlash(__d('api_generator', 'No package name was given'));
 			$this->redirect($this->referer());
 		}
-		$apiPackage = $this->ApiPackage->findByPackagePath($packagePath);
+		$apiPackage = $this->ApiPackage->findByPath($path);
 		if (empty($apiPackage)) {
 			$this->_notFound(__d('api_generator', 'No package exists in the index with that name'));
 		}

--- a/Model/ApiClass.php
+++ b/Model/ApiClass.php
@@ -103,15 +103,6 @@ class ApiClass extends ApiGeneratorAppModel {
 		}
 	}
 /**
- * Clears (truncates) the class index.
- *
- * @return void
- **/
-	public function clearIndex() {
-		$db = ConnectionManager::getDataSource($this->useDbConfig);
-		$db->truncate($db->fullTableName($this));
-	}
-/**
  * save the entry in the index for a ClassDocumentor object
  *
  * @param object $classDoc Instance of ClassDocumentor to add to database.

--- a/Model/ApiFile.php
+++ b/Model/ApiFile.php
@@ -251,7 +251,7 @@ class ApiFile extends Object {
 			return $docs;
 		}
 		if (!$this->isAllowed($filePath)) {
-			throw new Exception(__d('api_geneartor', '%s is not accesible or does not exist.', $filePath));
+			throw new Exception(__d('api_generator', '%s is not accesible or does not exist.', $filePath));
 		}
 		$this->_importCakeBaseClasses($filePath);
 		$this->_resolveDependancies($filePath, $options);

--- a/Model/ApiGeneratorAppModel.php
+++ b/Model/ApiGeneratorAppModel.php
@@ -37,6 +37,15 @@ class ApiGeneratorAppModel extends AppModel {
 		return $slugPath;
 	}
 /**
+ * Clears (truncates) the model index.
+ *
+ * @return void
+ **/
+	public function clearIndex() {
+		$db = ConnectionManager::getDataSource($this->useDbConfig);
+		$db->truncate($db->fullTableName($this));
+	}
+/**
  * Make a slug
  *
  * @param string $name Make a slug

--- a/Model/ApiPackage.php
+++ b/Model/ApiPackage.php
@@ -113,7 +113,7 @@ class ApiPackage extends ApiGeneratorAppModel {
 			$new = array(
 				'ApiPackage' => array(
 					'parent_id' => $parentId,
-					'package_path' => $this->makePath($path),
+					'path' => $this->makePath($path),
 					'slug' => $slug,
 					'name' => $package
 				)

--- a/Model/ApiPackage.php
+++ b/Model/ApiPackage.php
@@ -19,6 +19,8 @@
  * @since         ApiGenerator v 0.5
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+App::uses('ApiGeneratorAppModel', 'ApiGenerator.Model');
+
 class ApiPackage extends ApiGeneratorAppModel {
 /**
  * name
@@ -99,16 +101,20 @@ class ApiPackage extends ApiGeneratorAppModel {
  **/
 	public function updatePackageTree($packages) {
 		$parentId = null;
+		$path = array();
 		foreach ($packages as $package) {
 			$slug = $this->_makeSlug($package);
-			$existing = $this->findBySlug($slug, null, null, -1);
+			$existing = $this->findBySlugAndParentId($slug, $parentId, null, null, -1);
 			if ($existing) {
 				$parentId = $existing['ApiPackage']['id'];
+				$path[] = $slug;
 				continue;
 			}
+			$path[] = $slug;
 			$new = array(
 				'ApiPackage' => array(
 					'parent_id' => $parentId,
+					'package_path' => $this->_makePath($path),
 					'slug' => $slug,
 					'name' => $package
 				)
@@ -119,7 +125,7 @@ class ApiPackage extends ApiGeneratorAppModel {
 			}
 			$parentId = $this->id;
 		}
-		return true;
+		return $parentId;
 	}
 /**
  * Find The last package's id value.
@@ -130,6 +136,15 @@ class ApiPackage extends ApiGeneratorAppModel {
 		$lastPackage = array_pop($packages);
 		$last = $this->findBySlug($this->_makeSlug($lastPackage));
 		return $last['ApiPackage']['id'];
+	}
+/**
+ * Make a package path.
+ *
+ * @param mixed $path Package path
+ * @return string
+ **/
+ 	protected function _makePath($path){
+		return implode('/', $path);
 	}
 
 }

--- a/Model/ApiPackage.php
+++ b/Model/ApiPackage.php
@@ -104,17 +104,16 @@ class ApiPackage extends ApiGeneratorAppModel {
 		$path = array();
 		foreach ($packages as $package) {
 			$slug = $this->_makeSlug($package);
+			$path[] = $slug;
 			$existing = $this->findBySlugAndParentId($slug, $parentId, null, null, -1);
 			if ($existing) {
 				$parentId = $existing['ApiPackage']['id'];
-				$path[] = $slug;
 				continue;
 			}
-			$path[] = $slug;
 			$new = array(
 				'ApiPackage' => array(
 					'parent_id' => $parentId,
-					'package_path' => $this->_makePath($path),
+					'package_path' => $this->makePath($path),
 					'slug' => $slug,
 					'name' => $package
 				)
@@ -143,7 +142,7 @@ class ApiPackage extends ApiGeneratorAppModel {
  * @param mixed $path Package path
  * @return string
  **/
- 	protected function _makePath($path){
+ 	public function makePath($path){
 		return implode('/', $path);
 	}
 

--- a/README.mdown
+++ b/README.mdown
@@ -14,6 +14,8 @@ The Api Generator provides an easy to use always current documentation generatio
 
 Please See the [installation guide](http://cakephp.lighthouseapp.com/projects/42879/docs-installation).
 
+On Apache servers you may need `AllowEncodedSlashes` directive `On`
+
 ## Reporting issues
 
 If you have an issues with Api Generator please open a ticket on lighthouse http://cakephp.lighthouseapp.com/projects/42879-api-generator/overview

--- a/README.mdown
+++ b/README.mdown
@@ -14,8 +14,6 @@ The Api Generator provides an easy to use always current documentation generatio
 
 Please See the [installation guide](http://cakephp.lighthouseapp.com/projects/42879/docs-installation).
 
-On Apache servers you may need `AllowEncodedSlashes` directive `On`
-
 ## Reporting issues
 
 If you have an issues with Api Generator please open a ticket on lighthouse http://cakephp.lighthouseapp.com/projects/42879-api-generator/overview

--- a/Test/Case/Model/ApiPackageTest.php
+++ b/Test/Case/Model/ApiPackageTest.php
@@ -135,14 +135,14 @@ class ApiPackageTestCase extends CakeTestCase {
  **/
 	function testUpdatePackageTree() {
 		$packages = array('cake', 'model', 'datasource', 'dbo');
-		$result = $this->ApiPackage->updatePackageTree($packages);
+		$result = (bool) $this->ApiPackage->updatePackageTree($packages);
 		$this->assertTrue($result);
 
 		$result = $this->ApiPackage->findAllByParentId(4);
 		$this->assertEqual(count($result), 2);
 
 		$packages = array('cake', 'model', 'datasource', 'dbo');
-		$result = $this->ApiPackage->updatePackageTree($packages);
+		$result = (bool) $this->ApiPackage->updatePackageTree($packages);
 		$this->assertTrue($result);
 
 		$result = $this->ApiPackage->findAllBySlug('model');

--- a/Test/Case/View/Helper/ApiDocHelperTest.php
+++ b/Test/Case/View/Helper/ApiDocHelperTest.php
@@ -120,7 +120,7 @@ class ApiDocHelperTestCase extends CakeTestCase {
 
 		$result = $this->ApiDoc->packageLink('some.package.deep');
 		$expected = array(
-			'a' => array('href' => 'http://localhost/api_generator/api_packages/view/deep'),
+			'a' => array('href' => 'http://localhost/api_generator/api_packages/view/some/package/deep'),
 			'some.package.deep',
 			'/a'
 		);
@@ -128,7 +128,7 @@ class ApiDocHelperTestCase extends CakeTestCase {
 
 		$result = $this->ApiDoc->packageLink('  some.package.deep');
 		$expected = array(
-			'a' => array('href' => 'http://localhost/api_generator/api_packages/view/deep'),
+			'a' => array('href' => 'http://localhost/api_generator/api_packages/view/some/package/deep'),
 			'  some.package.deep',
 			'/a'
 		);

--- a/Test/Fixture/ApiPackageFixture.php
+++ b/Test/Fixture/ApiPackageFixture.php
@@ -22,7 +22,7 @@ class ApiPackageFixture extends CakeTestFixture {
 	var $fields = array(
 		'id' => array('type' => 'string', 'default' => NULL, 'length' => 36, 'null' => false, 'key' => 'primary'),
 		'parent_id' => array('type' => 'string', 'default' => NULL, 'length' => 36),
-		'package_path' => array('type' => 'string', 'null' => false, 'length' => 500),
+		'path' => array('type' => 'string', 'null' => false, 'length' => 500),
 		'name' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'slug' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'lft' => array('type' => 'integer'),
@@ -35,7 +35,7 @@ var $records = array(
 	array(
 		'id' => 1,
 		'parent_id' => null,
-		'package_path' => 'cake',
+		'path' => 'cake',
 		'name' => 'cake',
 		'slug' => 'cake',
 		'lft' => 1,
@@ -46,7 +46,7 @@ var $records = array(
 	array(
 		'id' => 2,
 		'parent_id' => 1,
-		'package_path' => 'cake/controller',
+		'path' => 'cake/controller',
 		'name' => 'controller',
 		'slug' => 'controller',
 		'lft' => 2,
@@ -57,7 +57,7 @@ var $records = array(
 	array(
 		'id' => 3,
 		'parent_id' => 2,
-		'package_path' => 'cake/controller/component',
+		'path' => 'cake/controller/component',
 		'name' => 'component',
 		'slug' => 'component',
 		'lft' => 3,
@@ -68,7 +68,7 @@ var $records = array(
 	array(
 		'id' => 4,
 		'parent_id' => 1,
-		'package_path' => 'cake/model',
+		'path' => 'cake/model',
 		'name' => 'model',
 		'slug' => 'model',
 		'lft' => 6,
@@ -79,7 +79,7 @@ var $records = array(
 	array(
 		'id' => 5,
 		'parent_id' => 4,
-		'package_path' => 'cake/model/behavior',
+		'path' => 'cake/model/behavior',
 		'name' => 'behavior',
 		'slug' => 'behavior',
 		'lft' => 7,

--- a/Test/Fixture/ApiPackageFixture.php
+++ b/Test/Fixture/ApiPackageFixture.php
@@ -22,6 +22,7 @@ class ApiPackageFixture extends CakeTestFixture {
 	var $fields = array(
 		'id' => array('type' => 'string', 'default' => NULL, 'length' => 36, 'null' => false, 'key' => 'primary'),
 		'parent_id' => array('type' => 'string', 'default' => NULL, 'length' => 36),
+		'package_path' => array('type' => 'string', 'null' => false, 'length' => 500),
 		'name' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'slug' => array('type' => 'string', 'length' => 255, 'null' => false),
 		'lft' => array('type' => 'integer'),
@@ -34,6 +35,7 @@ var $records = array(
 	array(
 		'id' => 1,
 		'parent_id' => null,
+		'package_path' => 'cake',
 		'name' => 'cake',
 		'slug' => 'cake',
 		'lft' => 1,
@@ -44,6 +46,7 @@ var $records = array(
 	array(
 		'id' => 2,
 		'parent_id' => 1,
+		'package_path' => 'cake/controller',
 		'name' => 'controller',
 		'slug' => 'controller',
 		'lft' => 2,
@@ -54,6 +57,7 @@ var $records = array(
 	array(
 		'id' => 3,
 		'parent_id' => 2,
+		'package_path' => 'cake/controller/component',
 		'name' => 'component',
 		'slug' => 'component',
 		'lft' => 3,
@@ -64,6 +68,7 @@ var $records = array(
 	array(
 		'id' => 4,
 		'parent_id' => 1,
+		'package_path' => 'cake/model',
 		'name' => 'model',
 		'slug' => 'model',
 		'lft' => 6,
@@ -74,6 +79,7 @@ var $records = array(
 	array(
 		'id' => 5,
 		'parent_id' => 4,
+		'package_path' => 'cake/model/behavior',
 		'name' => 'behavior',
 		'slug' => 'behavior',
 		'lft' => 7,

--- a/View/ApiPackages/json/view.ctp
+++ b/View/ApiPackages/json/view.ctp
@@ -5,7 +5,7 @@ $children = array();
 foreach ($apiPackage['ChildPackage'] as $child) {
 	$children[] = array(
 		'name' => $child['name'],
-		'url' => $this->ApiDoc->packageUrl($child['name'], array('ext' => 'json'))
+		'url' => $this->ApiDoc->packageUrl($child['name'], array($child['package_path'], 'ext' => 'json'))
 	);
 }
 

--- a/View/ApiPackages/json/view.ctp
+++ b/View/ApiPackages/json/view.ctp
@@ -7,7 +7,7 @@ foreach ($apiPackage['ChildPackage'] as $child) {
 		'name' => $child['name'],
 		'url' => $this->ApiDoc->packageUrl(
 			$child['name'], 
-			array_merge($this->ApiDoc->path($child['package_path']), array('ext' => 'json'))
+			array_merge($this->ApiDoc->path($child['path']), array('ext' => 'json'))
 		)
 	);
 }

--- a/View/ApiPackages/json/view.ctp
+++ b/View/ApiPackages/json/view.ctp
@@ -5,7 +5,10 @@ $children = array();
 foreach ($apiPackage['ChildPackage'] as $child) {
 	$children[] = array(
 		'name' => $child['name'],
-		'url' => $this->ApiDoc->packageUrl($child['name'], array($child['package_path'], 'ext' => 'json'))
+		'url' => $this->ApiDoc->packageUrl(
+			$child['name'], 
+			array_merge($this->ApiDoc->path($child['package_path']), array('ext' => 'json'))
+		)
 	);
 }
 

--- a/View/ApiPackages/view.ctp
+++ b/View/ApiPackages/view.ctp
@@ -7,7 +7,7 @@ $this->ApiDoc->setClassIndex($classIndex);
 	<?php if(!empty($apiPackage['ParentPackage']['name'])): ?>
 		<h3><?php echo __d('api_generator', 'Parent Package'); ?> </h3>
 		<ul class="package-list">
-			<li><?php echo $this->ApiDoc->packageLink($apiPackage['ParentPackage']['name']); ?></li>
+			<li><?php echo $this->ApiDoc->packageLink($apiPackage['ParentPackage']['name'], array($apiPackage['ParentPackage']['package_path'])); ?></li>
 		</ul>
 	<?php endif; ?>
 
@@ -15,7 +15,7 @@ $this->ApiDoc->setClassIndex($classIndex);
 		<h3><?php echo __d('api_generator', 'Child Packages'); ?></h3>
 		<ul class="package-list">
 		<?php foreach ($apiPackage['ChildPackage'] as $child): ?>
-			<li><?php echo $this->ApiDoc->packageLink($child['name']); ?></li>
+			<li><?php echo $this->ApiDoc->packageLink($child['name'], array($child['package_path'])); ?></li>
 		<?php endforeach; ?>
 		</ul>
 	<?php endif;?>

--- a/View/ApiPackages/view.ctp
+++ b/View/ApiPackages/view.ctp
@@ -7,7 +7,12 @@ $this->ApiDoc->setClassIndex($classIndex);
 	<?php if(!empty($apiPackage['ParentPackage']['name'])): ?>
 		<h3><?php echo __d('api_generator', 'Parent Package'); ?> </h3>
 		<ul class="package-list">
-			<li><?php echo $this->ApiDoc->packageLink($apiPackage['ParentPackage']['name'], array($apiPackage['ParentPackage']['package_path'])); ?></li>
+			<li>
+			<?php echo $this->ApiDoc->packageLink(
+				$apiPackage['ParentPackage']['name'], 
+				$this->ApiDoc->path($apiPackage['ParentPackage']['package_path'])
+			); ?>
+			</li>
 		</ul>
 	<?php endif; ?>
 
@@ -15,7 +20,12 @@ $this->ApiDoc->setClassIndex($classIndex);
 		<h3><?php echo __d('api_generator', 'Child Packages'); ?></h3>
 		<ul class="package-list">
 		<?php foreach ($apiPackage['ChildPackage'] as $child): ?>
-			<li><?php echo $this->ApiDoc->packageLink($child['name'], array($child['package_path'])); ?></li>
+			<li>
+			<?php echo $this->ApiDoc->packageLink(
+				$child['name'], 
+				$this->ApiDoc->path($child['package_path'])
+			); ?>
+			</li>
 		<?php endforeach; ?>
 		</ul>
 	<?php endif;?>

--- a/View/ApiPackages/view.ctp
+++ b/View/ApiPackages/view.ctp
@@ -10,7 +10,7 @@ $this->ApiDoc->setClassIndex($classIndex);
 			<li>
 			<?php echo $this->ApiDoc->packageLink(
 				$apiPackage['ParentPackage']['name'], 
-				$this->ApiDoc->path($apiPackage['ParentPackage']['package_path'])
+				$this->ApiDoc->path($apiPackage['ParentPackage']['path'])
 			); ?>
 			</li>
 		</ul>
@@ -23,7 +23,7 @@ $this->ApiDoc->setClassIndex($classIndex);
 			<li>
 			<?php echo $this->ApiDoc->packageLink(
 				$child['name'], 
-				$this->ApiDoc->path($child['package_path'])
+				$this->ApiDoc->path($child['path'])
 			); ?>
 			</li>
 		<?php endforeach; ?>

--- a/View/Helper/ApiDocHelper.php
+++ b/View/Helper/ApiDocHelper.php
@@ -351,7 +351,7 @@ class ApiDocHelper extends AppHelper {
  */
 	public function packageUrl($package, $url = array()) {
 		if (empty($url)) {
-			$slug = str_replace('.', '/', $this->slug($package));
+			$slug = str_replace('.', '/', $this->slug(trim($package)));
 			$url[] = $slug;
 		}		
 		$url = array_merge($this->_defaultUrl['package'], $url);

--- a/View/Helper/ApiDocHelper.php
+++ b/View/Helper/ApiDocHelper.php
@@ -262,6 +262,16 @@ class ApiDocHelper extends AppHelper {
 	}
 
 /**
+ * Splits package path by /'s to be usable as a passed argument(s) in URL.
+ *
+ * @param string $packagePath Package path stored in DB.
+ * @return array
+ **/
+	public function path($packagePath) {
+		return explode('/', $packagePath);
+	}
+
+/**
  * Create a nested inheritance tree from an array.
  * Uses an array stack like a tree. So
  *     array('foo', 'bar', 'baz')
@@ -296,7 +306,7 @@ class ApiDocHelper extends AppHelper {
 		$out = '<ul class="package-tree depth-'. $depth . '">' . "\n";
 		foreach ($packageTree as $branch) {
 			$children = null;
-			$link = $this->packageLink($branch['ApiPackage']['name'], array($branch['ApiPackage']['package_path']));
+			$link = $this->packageLink($branch['ApiPackage']['name'], $this->path($branch['ApiPackage']['package_path']));
 			if (!empty($branch['children'])) {
 				$depth++;
 				$children = $this->generatePackageTree($branch['children'], $depth);
@@ -317,7 +327,7 @@ class ApiDocHelper extends AppHelper {
 		$out = array();
 		foreach ($packageTree as $branch) {
 			$children = array();
-			$url = $this->packageUrl($branch['ApiPackage']['name'], array($branch['ApiPackage']['package_path']));
+			$url = $this->packageUrl($branch['ApiPackage']['name'], $this->path($branch['ApiPackage']['package_path']));
 			if (!empty($branch['children'])) {
 				$children = $this->generatePackageJsonTree($branch['children']);
 			}
@@ -352,8 +362,6 @@ class ApiDocHelper extends AppHelper {
 	public function packageUrl($package, $url = array()) {
 		if (empty($url)) {
 			$url = explode('.', $this->slug(trim($package)));
-		} else {
-			$url = $this->_mergePackageUrl($url);
 		}		
 		$url = array_merge($this->_defaultUrl['package'], $url);
 		return $this->url($url, true);
@@ -364,28 +372,13 @@ class ApiDocHelper extends AppHelper {
  *
  * @param string $package A package string with .'s in it.
  * @return string
- * @deprecated _mergePackageUrl instead
+ * @deprecated No use for it now
  **/
 	protected function _parsePackageString($package) {
 		$bits = explode('.', $package);
 		return $this->slug(end($bits));
 	}
-/**
- * merge url with a slash split package path and return new url.
- *
- * Note: It assumes the package path has always numeric key (0), 
- * so all other arguments you want to preserve must have string key
- *
- * @param string $package A package string with .'s in it.
- * @return string
- **/
-	protected function _mergePackageUrl($url) {
-		if (is_array($url) && isset($url[0])) {
-			$path = explode('/', $url[0]);
-			$url = $path + $url;
-		}
-		return $url;
-	}
+
 /**
  * Generate the visibility keywords for a method.
  *

--- a/View/Helper/ApiDocHelper.php
+++ b/View/Helper/ApiDocHelper.php
@@ -351,8 +351,9 @@ class ApiDocHelper extends AppHelper {
  */
 	public function packageUrl($package, $url = array()) {
 		if (empty($url)) {
-			$slug = str_replace('.', '/', $this->slug(trim($package)));
-			$url[] = $slug;
+			$url = explode('.', $this->slug(trim($package)));
+		} else {
+			$url = $this->_mergePackageUrl($url);
 		}		
 		$url = array_merge($this->_defaultUrl['package'], $url);
 		return $this->url($url, true);
@@ -363,12 +364,28 @@ class ApiDocHelper extends AppHelper {
  *
  * @param string $package A package string with .'s in it.
  * @return string
+ * @deprecated _mergePackageUrl instead
  **/
 	protected function _parsePackageString($package) {
 		$bits = explode('.', $package);
 		return $this->slug(end($bits));
 	}
-
+/**
+ * merge url with a slash split package path and return new url.
+ *
+ * Note: It assumes the package path has always numeric key (0), 
+ * so all other arguments you want to preserve must have string key
+ *
+ * @param string $package A package string with .'s in it.
+ * @return string
+ **/
+	protected function _mergePackageUrl($url) {
+		if (is_array($url) && isset($url[0])) {
+			$path = explode('/', $url[0]);
+			$url = $path + $url;
+		}
+		return $url;
+	}
 /**
  * Generate the visibility keywords for a method.
  *

--- a/View/Helper/ApiDocHelper.php
+++ b/View/Helper/ApiDocHelper.php
@@ -306,7 +306,7 @@ class ApiDocHelper extends AppHelper {
 		$out = '<ul class="package-tree depth-'. $depth . '">' . "\n";
 		foreach ($packageTree as $branch) {
 			$children = null;
-			$link = $this->packageLink($branch['ApiPackage']['name'], $this->path($branch['ApiPackage']['package_path']));
+			$link = $this->packageLink($branch['ApiPackage']['name'], $this->path($branch['ApiPackage']['path']));
 			if (!empty($branch['children'])) {
 				$depth++;
 				$children = $this->generatePackageTree($branch['children'], $depth);
@@ -327,7 +327,7 @@ class ApiDocHelper extends AppHelper {
 		$out = array();
 		foreach ($packageTree as $branch) {
 			$children = array();
-			$url = $this->packageUrl($branch['ApiPackage']['name'], $this->path($branch['ApiPackage']['package_path']));
+			$url = $this->packageUrl($branch['ApiPackage']['name'], $this->path($branch['ApiPackage']['path']));
 			if (!empty($branch['children'])) {
 				$children = $this->generatePackageJsonTree($branch['children']);
 			}

--- a/View/Helper/ApiDocHelper.php
+++ b/View/Helper/ApiDocHelper.php
@@ -296,7 +296,7 @@ class ApiDocHelper extends AppHelper {
 		$out = '<ul class="package-tree depth-'. $depth . '">' . "\n";
 		foreach ($packageTree as $branch) {
 			$children = null;
-			$link = $this->packageLink($branch['ApiPackage']['name']);
+			$link = $this->packageLink($branch['ApiPackage']['name'], array($branch['ApiPackage']['package_path']));
 			if (!empty($branch['children'])) {
 				$depth++;
 				$children = $this->generatePackageTree($branch['children'], $depth);
@@ -317,7 +317,7 @@ class ApiDocHelper extends AppHelper {
 		$out = array();
 		foreach ($packageTree as $branch) {
 			$children = array();
-			$url = $this->packageUrl($branch['ApiPackage']['name']);
+			$url = $this->packageUrl($branch['ApiPackage']['name'], array($branch['ApiPackage']['package_path']));
 			if (!empty($branch['children'])) {
 				$children = $this->generatePackageJsonTree($branch['children']);
 			}
@@ -350,12 +350,11 @@ class ApiDocHelper extends AppHelper {
  * @return string URL for the package.
  */
 	public function packageUrl($package, $url = array()) {
+		if (empty($url)) {
+			$slug = str_replace('.', '/', $this->slug($package));
+			$url[] = $slug;
+		}		
 		$url = array_merge($this->_defaultUrl['package'], $url);
-		$slug = $this->slug($package);
-		if (strpos($slug, '.') !== false) {
-			$slug = $this->_parsePackageString($slug);
-		}
-		$url[] = $slug;
 		return $this->url($url, true);
 	}
 

--- a/View/Helper/ApiUtilsHelper.php
+++ b/View/Helper/ApiUtilsHelper.php
@@ -85,7 +85,7 @@ class ApiUtilsHelper extends AppHelper {
 		$code= str_replace('<br />', "\n", $code);
 
 		/* Normalize Newlines */
-		$code= str_replace("\r", "\n", $code);
+		$code= str_replace(array("\r\n", "\r"), "\n", $code);
 
 		$lines= explode("\n", $code);
 


### PR DESCRIPTION
In reaction to this: http://cakephp.lighthouseapp.com/projects/42879/tickets/36-package-indexing-confuses-packages-with-different-parents#ticket-36-3
I tried to fix it. Not sure if it's best solution, but it applies the same logic as the current file browser, so it might work just fine
